### PR TITLE
Fixed a typo in the help prompt for Frink

### DIFF
--- a/humorbot/bot.py
+++ b/humorbot/bot.py
@@ -34,7 +34,7 @@ Generate a still image for search term _don't mind if i do_ with a different tex
 `/frink don't mind if i do | snare sux`
 `/frink image don't mind if i do | snare sux`
 Generate a still image for the search term _don't mind if i do_ with no text overlay:
-`/morbo don't mind if i do |`
+`/frink don't mind if i do |`
 Generate a selection of still images for _don't mind if i do_:
 `/frink images don't mind if i do`
 Generate a GIF for _don't mind if i do_:


### PR DESCRIPTION
I noticed that the `/frink help` command has a stray `morbo` in there.
I didn't see any contributing notes, so here's a PR ;) 

<img width="713" alt="Screen Shot 2019-03-13 at 1 35 50 PM" src="https://user-images.githubusercontent.com/1695446/54312774-f8040480-4594-11e9-900a-068ab3d849ca.png">
